### PR TITLE
binder_ndk_sys: Allow code to build inside a workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,6 @@ members = [
     "tests",
 ]
 
-exclude = ["target/*"]
-
 [workspace.package]
 edition = "2021"
 version = "0.2.0"

--- a/binder_ndk_sys/build.rs
+++ b/binder_ndk_sys/build.rs
@@ -17,6 +17,8 @@ rust-version = "1.67"
 
 [lib]
 crate-type = ["cdylib"]
+
+[workspace]
 "#;
 
 fn build_stub() -> Result<()> {
@@ -42,7 +44,7 @@ fn build_stub() -> Result<()> {
     f.flush()?;
 
     let target = env::var("TARGET")?;
-    Command::new("cargo")
+    let s = Command::new("cargo")
         .arg("build")
         .arg("--target")
         .arg(&target)
@@ -53,10 +55,12 @@ fn build_stub() -> Result<()> {
         .current_dir(&project_path)
         .status()?;
 
+    assert!(s.success(), "{s:?}");
+
     // we always use debug build for stub due to speed!
     println!(
         "cargo:rustc-link-search={}",
-        format!("{}/{}/{}", outdir, target, "debug")
+        format_args!("{}/{}/{}", outdir, target, "debug")
     );
     println!("cargo:rustc-link-lib=binder_ndk");
 


### PR DESCRIPTION
CC @rsglobal for https://github.com/Kernel-SU/binder_rs/pull/9#issuecomment-2454960410

When this file is generated into `target/`, it might still think it belongs to a parent `[workspace]` crate and fail to compile:

       Compiling binder_ndk_sys v0.2.0 (binder_rs/binder_ndk_sys)
    error: failed to run custom build command for `binder_ndk_sys v0.2.0 (binder_rs/binder_ndk_sys)`

    Caused by:
      process didn't exit successfully: `my-hidl-crate/target/debug/build/binder_ndk_sys-a839da7d88e99ce9/build-script-build` (exit status: 101)
      --- stdout
      cargo:rerun-if-changed=src/BinderBindings.hpp
      cargo:rerun-if-changed=src/symbols.txt

      --- stderr
      error: current package believes it's in a workspace when it's not:
      current:   my-hidl-crate/target/aarch64-linux-android/debug/build/binder_ndk_sys-a3aef417509c2387/out/libbinder_ndk/Cargo.toml
      workspace: my-hidl-crate/Cargo.toml

      this may be fixable by ensuring that this crate is depended on by the workspace root: my-hidl-crate/Cargo.toml
      Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.

Follow the suggestion from `cargo` and turn the generated `libbinder_ndk/Cargo.toml` crate into a new workspace root.

This would have previously gone unnoticed as the invocation of `cargo build` did not check whether it had a nonzero exit code: this is now asserted on too.

We also revert commit 6627342 ("Fix build failed when used in workspace (#5)") which was working around the issue _within this repository only_, but that doesn't apply to users/consumers of this crate via i.e. crates.io.
